### PR TITLE
認証済みユーザーの自動リダイレクト機能追加

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -5,10 +5,11 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Github, Mail } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { toast } from "@/components/ui/use-toast";
+import { useRouter } from "next/navigation";
 
 const containerVariants = {
   hidden: { opacity: 0, y: 20 },
@@ -25,8 +26,21 @@ export default function AuthPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isSignIn, setIsSignIn] = useState(true);
-  const { signIn, signUp, signInWithGithub, signInWithGoogle, isLoading } =
-    useAuth();
+  const {
+    signIn,
+    signUp,
+    signInWithGithub,
+    signInWithGoogle,
+    isLoading,
+    user,
+  } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      router.push("/dashboard");
+    }
+  }, [user, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## 変更内容

### 機能追加
- ログイン済みユーザーが認証画面（ログイン/登録画面）にアクセスした場合、自動的にダッシュボードにリダイレクトする機能を追加
- useEffectフックを使用して、コンポーネントマウント時やユーザー状態変更時にログイン状態をチェック
- ユーザーがログイン済みの場合は、/dashboard へリダイレクト

### 改善点
- ユーザー体験の向上 - ログイン済みユーザーが不要に認証画面を見る必要がなくなった
- セキュリティの強化 - ログイン済みユーザーの再認証を防止

### 技術的な詳細
- React useEffect フックを使用したマウント時の状態チェック
- UserAuth コンテキストの活用
- Next.js のルーターを使用したプログラムによるナビゲーション